### PR TITLE
[aws-xray] Change Daemonset API version to support K8S 1.16

### DIFF
--- a/stable/aws-xray/Chart.yaml
+++ b/stable/aws-xray/Chart.yaml
@@ -1,5 +1,5 @@
 name: aws-xray
-version: 1.3.1
+version: 1.3.2
 appVersion: "3.2.0"
 description: AWS X-Ray helps you debug and analyze your microservices applications with request tracing
 home: https://aws.amazon.com/xray/

--- a/stable/aws-xray/Chart.yaml
+++ b/stable/aws-xray/Chart.yaml
@@ -1,5 +1,5 @@
 name: aws-xray
-version: 1.3.2
+version: 2.0.0
 appVersion: "3.2.0"
 description: AWS X-Ray helps you debug and analyze your microservices applications with request tracing
 home: https://aws.amazon.com/xray/

--- a/stable/aws-xray/README.md
+++ b/stable/aws-xray/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a [AWS X-Ray](https://aws.amazon.com/xray/) deployment on 
 
 ## Prerequisites
 
-- Kubernetes 1.4+ with Beta APIs enabled
+- Kubernetes 1.9+
 
 ## Installing the Chart
 

--- a/stable/aws-xray/templates/daemonset.yaml
+++ b/stable/aws-xray/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "aws-xray.fullname" . }}


### PR DESCRIPTION
#### PR Checklist
- [x] Chart Version bumped
- [x] Variables and other changes are documented in the README.md


**What this PR does / why we need it**:
Change Daemonset API version from `extensions/v1beta1` to `apps/v1` in order to support Kubernetes 1.16+

**Special notes for your reviewer**:
Reference: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
