### PR TITLE
Fix default for serviceMonitor.namespace in README.md

### DIFF
--- a/charts/goldpinger/Chart.yaml
+++ b/charts/goldpinger/Chart.yaml
@@ -11,4 +11,4 @@ name: goldpinger
 sources:
   - https://github.com/bloomberg/goldpinger
   - https://github.com/okgolove/helm-charts
-version: 3.0.1
+version: 3.0.2

--- a/charts/goldpinger/README.md
+++ b/charts/goldpinger/README.md
@@ -76,7 +76,7 @@ The following table lists the configurable parameters of the Goldpinger chart an
 | `serviceMonitor.enabled`       | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` |
 | `serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}` |
 | `serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels. | `false`|
-| `serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as goldpinger` |
+| `serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `monitoring` |
 | `serviceMonitor.scrapeInterval` | interval between Prometheus scraping | `30s` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,


### PR DESCRIPTION
#### PR Checklist
- [x] Chart Version bumped

**What this PR does / why we need it**:
The README.md tells us that the ServiceMonitor gets created in the same namespace as Goldpinger. But "monitoring" is set explicitly in [charts/goldpinger/values.yaml#L91](https://github.com/okgolove/helm-charts/blob/master/charts/goldpinger/values.yaml#L91)