### PR TITLE
Create ServiceMonitor in same namespace as Goldpinger by default

### DIFF
--- a/charts/goldpinger/Chart.yaml
+++ b/charts/goldpinger/Chart.yaml
@@ -11,4 +11,4 @@ name: goldpinger
 sources:
   - https://github.com/bloomberg/goldpinger
   - https://github.com/okgolove/helm-charts
-version: 3.2.0
+version: 4.0.0

--- a/charts/goldpinger/Chart.yaml
+++ b/charts/goldpinger/Chart.yaml
@@ -11,4 +11,4 @@ name: goldpinger
 sources:
   - https://github.com/bloomberg/goldpinger
   - https://github.com/okgolove/helm-charts
-version: 3.1.1
+version: 3.2.0

--- a/charts/goldpinger/README.md
+++ b/charts/goldpinger/README.md
@@ -76,7 +76,7 @@ The following table lists the configurable parameters of the Goldpinger chart an
 | `serviceMonitor.enabled`       | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` |
 | `serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}` |
 | `serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels. | `false`|
-| `serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `monitoring` |
+| `serviceMonitor.namespace` | namespace where servicemonitor resource should be created, same as Goldpinger if not specified | `` |
 | `serviceMonitor.scrapeInterval` | interval between Prometheus scraping | `30s` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/charts/goldpinger/values.yaml
+++ b/charts/goldpinger/values.yaml
@@ -88,6 +88,6 @@ serviceMonitor:
   enabled: false
   selector:
     prometheus: "kube-prometheus"
-  namespace: "monitoring"
+  namespace:
   interval: 30s
   # honorLabels: true

--- a/charts/goldpinger/values.yaml
+++ b/charts/goldpinger/values.yaml
@@ -88,6 +88,6 @@ serviceMonitor:
   enabled: false
   selector:
     prometheus: "kube-prometheus"
-  namespace:
+  # namespace: monitoring
   interval: 30s
   # honorLabels: true


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
See #30: Creating the ServiceMonitor in namespace "monitoring" can be confusing. Now the SM is created in the same namespace as Goldpinger by default.

