### PR TITLE
Expose TCP port

### DIFF
--- a/charts/aws-xray/Chart.yaml
+++ b/charts/aws-xray/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
 name: aws-xray
 sources:
   - https://github.com/aws/aws-xray-daemon
-version: 3.1.1
+version: 3.2.0

--- a/charts/aws-xray/README.md
+++ b/charts/aws-xray/README.md
@@ -55,7 +55,7 @@ The following table lists the configurable parameters of the AWS X-Ray chart and
 | `xray.region`                        | AWS region you deploy AWS X-Ray to          | ``                                                         |
 | `xray.loglevel`                      | AWS X-Ray daemon log level                  | `prod`                                                     |
 | `xray.roleArn`                       | AWS IAM role to assume                      | ``                                                         |
-| `service.port`                       | Service UDP port                            | `2000`                                                     |
+| `service.port`                       | Service UDP and TCP port                    | `2000`                                                     |
 | `nodeSelector`                       | Node labels for pod assignment              | `{}`                                                       |
 | `tolerations`                        | List of node taints to tolerate             | `[]`                                                       |
 | `affinity`                           | Map of node/pod affinities                  | `{}`                                                       |

--- a/charts/aws-xray/templates/configmap.yaml
+++ b/charts/aws-xray/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
       # Change the address and port on which the daemon listens for UDP packets containing segment documents.
       # Make sure we listen on all IP's by default for the k8s setup
       UDPAddress: "0.0.0.0:2000"
+      TCPAddress: "0.0.0.0:2000"
     Logging:
       LogRotation: true
       # Change the log level, from most verbose to least: dev, debug, info, warn, error, prod (default).

--- a/charts/aws-xray/templates/daemonset.yaml
+++ b/charts/aws-xray/templates/daemonset.yaml
@@ -38,6 +38,10 @@ spec:
           containerPort: 2000
           hostPort: 2000
           protocol: UDP
+        - name: xray-tcp
+          containerPort: 2000
+          hostPort: 2000
+          protocol: TCP
         volumeMounts:
         - name: config-volume
           mountPath: /aws/xray

--- a/charts/aws-xray/templates/service.yaml
+++ b/charts/aws-xray/templates/service.yaml
@@ -12,7 +12,10 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       protocol: UDP
-      name: incoming
+      name: xray-ingest
+    - port: {{ .Values.service.port }}
+      protocol: TCP
+      name: xray-tcp
   selector:
     app.kubernetes.io/name: {{ include "aws-xray.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/aws-xray/templates/service.yaml
+++ b/charts/aws-xray/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       protocol: UDP
-      name: xray-ingest
+      name: incoming
     - port: {{ .Values.service.port }}
       protocol: TCP
       name: xray-tcp


### PR DESCRIPTION
AWS XRay Daemon chart

#### PR Checklist
- [x] Chart Version bumped
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
PR exposes TCP port to 0.0.0.0:2000 allowing to listen for X-Ray service calls (i.e. sampling rules)
Without configmap change following warning observed in XRay logs:

`WARN -- : failed to fetch X-Ray sampling rules due to Failed to open TCP connection to aws-xray.kube-system:2000 (Connection refused - connect(2) for "aws-xray.kube-system" port 2000)`

Config file [reference](https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon-configuration.html#xray-daemon-configuration-configfile)

