### PR TITLE
feature: allow users to opt out of cluster scoped RBAC

### DIFF
--- a/charts/goldpinger/Chart.yaml
+++ b/charts/goldpinger/Chart.yaml
@@ -11,4 +11,4 @@ name: goldpinger
 sources:
   - https://github.com/bloomberg/goldpinger
   - https://github.com/okgolove/helm-charts
-version: 5.0.0
+version: 5.0.1

--- a/charts/goldpinger/README.md
+++ b/charts/goldpinger/README.md
@@ -49,7 +49,8 @@ The following table lists the configurable parameters of the Goldpinger chart an
 | `image.repository`             | Goldpinger image                             | `bloomberg/goldpinger` |
 | `image.tag`                    | Goldpinger image tag                         | `3.2.0`                |
 | `pullPolicy`                   | Image pull policy                            | `IfNotPresent`         |
-| `rbac.create`                  | Install required rbac clusterrole            | `true`                 |
+| `rbac.create`                  | Install required rbac resources              | `true`                 |
+| `rbac.clusterscoped`           | Install optional cluster scoped rbac         | `true`                 |
 | `serviceAccount.create`        | Enable ServiceAccount creation               | `true`                 |
 | `serviceAccount.name`          | ServiceAccount for Goldpinger pods           | `default`              |
 | `goldpinger.port`              | Goldpinger app port listen to                | `80`                   |

--- a/charts/goldpinger/templates/clusterrole.yaml
+++ b/charts/goldpinger/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.rbac.clusterscoped }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/goldpinger/templates/clusterrolebinding.yaml
+++ b/charts/goldpinger/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.rbac.clusterscoped }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/goldpinger/templates/role.yaml
+++ b/charts/goldpinger/templates/role.yaml
@@ -1,0 +1,21 @@
+{{- if or .Values.podSecurityPolicy.enabled (not .Values.rbac.clusterscoped) }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "goldpinger.fullname" . }}-pod-security-policy
+  labels:
+    {{- include "goldpinger.labels" . | nindent 4 }}
+rules:
+{{- if not .Values.rbac.clusterscoped }}
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
+{{- end }}
+{{- if .Values.podSecurityPolicy.enabled }}
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: [{{ .Values.podSecurityPolicy.policyName | quote }}]
+  verbs: ["use"]
+{{- end }}
+{{- end }}

--- a/charts/goldpinger/templates/rolebinding.yaml
+++ b/charts/goldpinger/templates/rolebinding.yaml
@@ -1,17 +1,4 @@
-{{- if .Values.podSecurityPolicy.enabled }}
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "goldpinger.fullname" . }}-pod-security-policy
-  labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
-rules:
-- apiGroups: ["extensions"]
-  resources: ["podsecuritypolicies"]
-  resourceNames: [{{ .Values.podSecurityPolicy.policyName | quote }}]
-  verbs: ["use"]
----
+{{- if or .Values.podSecurityPolicy.enabled (not .Values.rbac.clusterscoped) }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/goldpinger/values.yaml
+++ b/charts/goldpinger/values.yaml
@@ -14,6 +14,7 @@ image:
 
 rbac:
   create: true
+  clusterscoped: true
 serviceAccount:
   create: true
   name:


### PR DESCRIPTION
#### PR Checklist
- [x] Chart Version bumped
- [x] Variables and other changes are documented in the README.md

**What this PR does / why we need it**:
Goldpinger optionally searches for Pods in every namespace, but used to have unconditional cluster scoped RBAC to do so. Combined with the fact that it's role is able to "use" an unrestricted PSP, this is not very least privilege.

This commit does a couple of things:
- splits `podsecuritypolicy.yaml` into `role.yaml` and `rolebinding.yaml`, so it's more like its cluster scoped equivalents
- make both cluster scoped as namespaced role/-binding optional

**Which issue this PR fixes** 

n/a. If needed, I can raise one.

**Special notes for your reviewer**:

This is how I tested it:
- `helm template --set rbac.clusterscoped=false --set podSecurityPolicy.enabled=false .`. Result: `Role` and `Rolebinding`, without PSP reference
- `helm template --set rbac.clusterscoped=false --set podSecurityPolicy.enabled=true .`. Result: `Role` and `Rolebinding`, including PSP reference
- `helm template --set rbac.clusterscoped=true --set podSecurityPolicy.enabled=false .`. Result: `ClusterRole` and `ClusterRolebinding`, without PSP reference
- `helm template --set rbac.clusterscoped=true --set podSecurityPolicy.enabled=true .`. Result: `CluserRole`, `ClusterRolebinding`, `Role` and `Rolebinding`, including PSP reference

I made it in such a way it's backwards compatible. I think there is a good argument to change `rbac.clusterscoped` to false by default (as goldpinger operates in its namespace by default too), but I'll leave that up to the owners.