### PR TITLE
chore: fix lint workflow

### DIFF
--- a/.github/workflows/lint_test.yaml
+++ b/.github/workflows/lint_test.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: helm/kind-action@v1.4.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          node_image: "kindest/node:v1.24.6"
+          node_image: ${{ matrix.kubernetes_version }}
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --helm-extra-set-args "--set=service.type=ClusterIP"


### PR DESCRIPTION
kind does not support LoadBalancer service type from scratch, helm fails if service is pending

Use matrix
