### PR TITLE
feat: set `hostPort` and `hostNetwork` if `USE_HOST_IP` is defined and true; fix `extraEnv`/`containerSecurityContext` ordering

### DIFF
--- a/charts/goldpinger/Chart.yaml
+++ b/charts/goldpinger/Chart.yaml
@@ -11,4 +11,4 @@ name: goldpinger
 sources:
   - https://github.com/bloomberg/goldpinger
   - https://github.com/okgolove/helm-charts
-version: 5.4.3
+version: 5.4.4

--- a/charts/goldpinger/templates/daemonset.yaml
+++ b/charts/goldpinger/templates/daemonset.yaml
@@ -47,17 +47,22 @@ spec:
               value: "{{ .Values.goldpinger.port }}"
             - name: LABEL_SELECTOR
               value: "app.kubernetes.io/name={{ include "goldpinger.name" . }}"
+            {{- if .Values.extraEnv }}
+            {{ toYaml .Values.extraEnv | nindent 12 }}
+            {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-{{- if .Values.extraEnv }}
-{{ toYaml .Values.extraEnv | indent 12 }}
-{{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.goldpinger.port }}
               protocol: TCP
+              {{- range $k := .Values.extraEnv }}
+              {{- if and (eq $k.name "USE_HOST_IP") (eq $k.value "true") }}
+              hostPort: {{ $.Values.goldpinger.port }}
+              {{- end }}
+              {{- end }}
           livenessProbe:
             httpGet:
               path: /
@@ -68,6 +73,11 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- range $k := .Values.extraEnv }}
+      {{- if and (eq $k.name "USE_HOST_IP") (eq $k.value "true") }}
+      hostNetwork: true
+      {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION


#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped

<!--
Thank you for contributing to okgolove/helm-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This will allow the usage of Goldpinger's `USE_HOST_IP` parameter. If the chart detects `USE_HOST_IP` being set to `true`, it'll deploy the Pod with `hostPort` and `hostNetwork: true`. 

Additionally, I've fixed the `extraEnv`/`containerSecurityContext` ordering, which got broken by PR #73 and would've rendered an invalid DaemonSet, if both `containerSecurityContext` and `extraEnv` are defined.



**Special notes for your reviewer**:
@okgolove