### PR TITLE
support custom container port

### DIFF
--- a/charts/aws-xray/Chart.yaml
+++ b/charts/aws-xray/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
 name: aws-xray
 sources:
   - https://github.com/aws/aws-xray-daemon
-version: 4.0.9
+version: 4.0.10

--- a/charts/aws-xray/templates/configmap.yaml
+++ b/charts/aws-xray/templates/configmap.yaml
@@ -17,8 +17,8 @@ data:
     Socket:
       # Change the address and port on which the daemon listens for UDP packets containing segment documents.
       # Make sure we listen on all IP's by default for the k8s setup
-      UDPAddress: "0.0.0.0:2000"
-      TCPAddress: "0.0.0.0:2000"
+      UDPAddress: "0.0.0.0:{{ .Values.xray.containerPort }}"
+      TCPAddress: "0.0.0.0:{{ .Values.xray.containerPort }}"
     Logging:
       LogRotation: true
       # Change the log level, from most verbose to least: dev, debug, info, warn, error, prod (default).

--- a/charts/aws-xray/templates/daemonset.yaml
+++ b/charts/aws-xray/templates/daemonset.yaml
@@ -39,12 +39,12 @@ spec:
           command: ["/xray", "-c", "/aws/xray/config.yaml"]
           ports:
             - name: xray-ingest
-              containerPort: 2000
-              hostPort: 2000
+              containerPort: {{ .Values.xray.containerPort }}
+              hostPort: {{ .Values.xray.containerPort }}
               protocol: UDP
             - name: xray-tcp
-              containerPort: 2000
-              hostPort: 2000
+              containerPort: {{ .Values.xray.containerPort }}
+              hostPort: {{ .Values.xray.containerPort }}
               protocol: TCP
           volumeMounts:
             - name: config-volume

--- a/charts/aws-xray/templates/service.yaml
+++ b/charts/aws-xray/templates/service.yaml
@@ -8,9 +8,11 @@ spec:
   clusterIP: None
   ports:
     - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.xray.containerPort }}
       protocol: UDP
       name: incoming
     - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.xray.containerPort }}
       protocol: TCP
       name: xray-tcp
   selector:

--- a/charts/aws-xray/values.yaml
+++ b/charts/aws-xray/values.yaml
@@ -37,6 +37,8 @@ xray:
   loglevel: prod
   # ARN of IAM role to assume
   roleArn:
+  # Port to be used as a hostPort and containerPort on the pod
+  containerPort: 2000
 
 service:
   port: 2000


### PR DESCRIPTION
#### PR Checklist
- [X] Chart Version bumped

**What this PR does / why we need it**:
- add support to customize the container port

**Special notes for your reviewer**:
- Since aws-xray is using hostnetwork, we may have some usecases where the port 2000 is already used by another pod (that also uses hostnetwork)
